### PR TITLE
refactor: Simplify branching strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main ]
   workflow_dispatch:
 
 env:
@@ -141,7 +141,7 @@ jobs:
   docker-build:
     name: Build Docker Images
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Summary
Simplified the branching strategy to use only the main branch with feature branches, removing the develop branch.

## Changes
- Removed develop branch references from GitHub Actions workflow
- Updated CI/CD to only trigger on main branch
- Deleted develop branch from repository

## Branching Strategy
Going forward:
1. All work done in feature branches created from main
2. Feature branches merged to main via pull requests
3. Main branch is always production-ready

🤖 Generated with [Claude Code](https://claude.ai/code)