### PR TITLE
fix: resolve e2e test database configuration issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ main, develop, 'feature/**' ]
+    branches: [ main, develop ]
   pull_request:
     branches: [ main, develop ]
   workflow_dispatch:
@@ -148,18 +148,8 @@ jobs:
     - name: Build backend
       run: dotnet build TennisApp/TennisApp.sln --no-restore --configuration Release
       
-    - name: Run database migrations
+    - name: Create test configuration
       run: |
-        dotnet ef database update --project TennisApp/TennisApp.Infrastructure/TennisApp.Infrastructure.csproj \
-          --startup-project TennisApp/TennisApp.API/TennisApp.API.csproj \
-          --configuration Release
-      env:
-        ConnectionStrings__DefaultConnection: "Host=localhost;Database=tennisapp_test;Username=postgres;Password=postgres"
-      continue-on-error: true # Database might not have migrations yet
-      
-    - name: Start backend API
-      run: |
-        # Create appsettings.Test.json with proper configuration
         cat > TennisApp/TennisApp.API/appsettings.Test.json <<EOF
         {
           "ConnectionStrings": {
@@ -184,6 +174,17 @@ jobs:
         }
         EOF
         
+    - name: Run database migrations
+      run: |
+        dotnet ef database update --project TennisApp/TennisApp.Infrastructure/TennisApp.Infrastructure.csproj \
+          --startup-project TennisApp/TennisApp.API/TennisApp.API.csproj \
+          --configuration Release
+      env:
+        ASPNETCORE_ENVIRONMENT: Test
+        ConnectionStrings__DefaultConnection: "Host=localhost;Database=tennisapp_test;Username=postgres;Password=postgres"
+      
+    - name: Start backend API
+      run: |
         # Start the API in background
         dotnet run --project TennisApp/TennisApp.API/TennisApp.API.csproj \
           --configuration Release \


### PR DESCRIPTION
## Summary
- Fixed e2e test failures caused by incorrect database configuration
- Removed duplicate workflow triggers for feature branches

## Changes
### Database Configuration Fix
- Created appsettings.Test.json BEFORE running migrations (was happening after)
- Added ASPNETCORE_ENVIRONMENT=Test to migration step
- Removed continue-on-error from migration step since it should now work properly

### Workflow Optimization
- Removed 'feature/**' from push triggers to prevent duplicate checks
- PRs from feature branches now only trigger one set of checks (pull_request event)
- This reduces CI resource usage and confusion from duplicate check runs

## Testing
- E2E tests should now properly connect to PostgreSQL with correct credentials
- Only one set of checks will run for PRs (not duplicate push + PR checks)

## Related Issues
- Fixes e2e test failures in CI pipeline
- Addresses duplicate check runs mentioned by user